### PR TITLE
Implement setting environment variables

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -143,6 +143,25 @@ function h$getenv(name, name_off) {
     return null;
 }
 
+function h$putenv(name, name_off) {
+    TRACE_ENV("putenv");
+#ifndef GHCJS_BROWSER
+    if(h$isNode) {
+        var nv = h$decodeUtf8z(name, name_off).split('=', 2);
+        if(nv.length !== 2) return 0;
+        var n = nv[0];
+        var v = nv[1];
+        if (v !== '') {
+            process.env[n] = v;
+        }
+        else {
+            delete process.env[n];
+        }
+    }
+#endif
+    return 0;
+}
+
 function h$errorBelch() {
   h$log("### errorBelch: do we need to handle a vararg function here?");
 }


### PR DESCRIPTION
Currently using `System.Environment.setEnv` crashes with this:

```
uncaught exception in Haskell main thread: ReferenceError: h$putenv is not defined
ReferenceError: h$putenv is not defined
    at h$$mi (/Users/mtolly/git/setenv/dist/build/setenv/setenv.jsexe/all.js:38868:11)
    at h$mainLoop (/Users/mtolly/git/setenv/dist/build/setenv/setenv.jsexe/all.js:10661:25)
    at /Users/mtolly/git/setenv/dist/build/setenv/setenv.jsexe/all.js:11127:13
    at /Users/mtolly/git/setenv/dist/build/setenv/setenv.jsexe/all.js:13454:17
    at Object.wrapper [as oncomplete] (fs.js:521:5)
```

So I implemented that apparently missing function :)
