### PR TITLE
Fix converting long Text to JS string

### DIFF
--- a/src/string.js
+++ b/src/string.js
@@ -348,11 +348,17 @@ function h$toStr(b,o,l) {
   var end = 2*(o+l);
   var k = 0;
   var dv = b.dv;
+  var s = '';
   for(var i=2*o;i<end;i+=2) {
     var cc = dv.getUint16(i,true);
     a[k++] = cc;
+    if(k === 60000) {
+      s += String.fromCharCode.apply(this, a);
+      k = 0;
+      a = [];
+    }
   }
-  return String.fromCharCode.apply(this, a);
+  return s + String.fromCharCode.apply(this, a);
 }
 
 /*


### PR DESCRIPTION
In (at least) iOS Safari, converting a long Text (over 65536 chars) to a JS string fails due to `apply`ing a large array as function arguments to `String.fromCharCode`; see https://bugs.webkit.org/show_bug.cgi?id=80797.
This breaks the array up into chunks that fit under this limit, concatenating the strings as it goes.
A quick search says there might be a few more `String.fromCharCode.apply` calls nearby with the same issue, but this patch successfully fixed the conversion for me.
