### PR TITLE
Fix: typeof returns 'undefined', not undefined.

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -20,7 +20,7 @@ var h$isJsShell = false; // runtime is SpiderMonkey jsshell
 var h$isJsCore  = false; // runtime is JavaScriptCore jsc
 var h$isBrowser = false; // running in browser or everything else
 // load all required node.js modules
-if(typeof process !== undefined && (typeof h$TH !== 'undefined' || (typeof require !== 'undefined' && typeof module !== 'undefined' && module.exports))) {
+if(typeof process !== 'undefined' && (typeof h$TH !== 'undefined' || (typeof require !== 'undefined' && typeof module !== 'undefined' && module.exports))) {
     h$isNode = true;
     // we have to use these names for the closure compiler externs to work
     var fs            = require('fs');


### PR DESCRIPTION
Prevents using GHCJS generated code as CommonJS module (i.e. in project compiled with [brunch](http://brunch.io)).