### PR TITLE
implementing GC semantics for WeakPointer more like ghc

### DIFF
--- a/src/gc.js
+++ b/src/gc.js
@@ -248,7 +248,6 @@ function h$gc(t) {
 function h$markRetained() {
     var iter, marked, w, mark = h$gcMark;
     var newList = [];
-    var toFinalize = [];
 
     /*
       2. Scan the Weak Pointer List. If a weak pointer object has a key that is
@@ -303,12 +302,12 @@ function h$markRetained() {
 
 	TRACE_GC("mark retained iteration 2/2");
 
-	if (w.val !== null) {
-	    // FIXME: we should set v.val to null ??? aka tombstone
-	}
+	// FIXME: we should set v.val to null ??? aka tombstone
+	//if (w.val !== null && !IS_MARKED(w.val)) {
+	//  w.val = null;
+        //}
 
 	if (w.finalizer !== null) {
-	    toFinalize.push(w.finalizer);
 	    if (!IS_MARKED(w.finalizer)) {
 		h$follow(w.finalizer);
 	    }
@@ -328,8 +327,6 @@ function h$markRetained() {
 	    MARK_OBJ(w);
 	}
     }
-
-    return toFinalize;
 }
 
 function h$markThread(t) {

--- a/src/gc.js
+++ b/src/gc.js
@@ -262,6 +262,7 @@ function h$markRetained() {
 	for (var i = 0; i < h$weakPointerList.length; ++i) {
 	    w = h$weakPointerList[i];
 	    if (w === null) {
+		// don't handle items deleted in earlier iteration
 		continue;
 	    }
 	    if (IS_MARKED(w.keym)) {
@@ -276,7 +277,10 @@ function h$markRetained() {
 		}
 
 		newList.push(w);
+		// instead of removing the item from the h$weakpointerList
+		// we set it to null if we push it to newList.
 		h$weakPointerList[i] = null;
+
 		marked = true;
 	    }
 	}
@@ -298,6 +302,7 @@ function h$markRetained() {
     for (var i = 0; i < h$weakPointerList.length; ++i) {
 	w = h$weakPointerList[i];
 	if (w === null) {
+	    // don't handle items deleted in step 2
 	    continue;
 	}
 

--- a/src/gc.js
+++ b/src/gc.js
@@ -312,8 +312,10 @@ function h$markRetained() {
 	    if(w.val !== null) {
 		w.val = null;
 	    }
-	    if (w.finalizer !== null && !IS_MARKED(w.finalizer)) {
-		h$follow(w.finalizer);
+	    if (w.finalizer !== null) {
+		if (!IS_MARKED(w.finalizer))
+		    h$follow(w.finalizer);
+
 		toFinalize.push(w.finalizer);
 	    }
 	}

--- a/src/weak.js
+++ b/src/weak.js
@@ -14,20 +14,10 @@ function h$traceWeak() { h$log.apply(h$log, arguments) }
 #endif
 
 // called by the GC after marking the heap
-function h$finalizeWeaks() {
+function h$finalizeWeaks(toFinalize) {
     var mark = h$gcMark;
-    TRACE_WEAK("finalizeWeaks: " + mark + " " + h$finalizers.size());
-    var i, w, toFinalize = [];
-    var iter = h$finalizers.iter();
-    while((w = iter.next()) !== null) {
-        TRACE_WEAK("checking weak with finalizer: " + h$stableNameInt(w.m));
-        TRACE_WEAK("finalizer mark: " + w.m.m + " - " + mark);
-        if((w.m.m&3) !== mark) {
-            iter.remove();
-            toFinalize.push(w);
-            TRACE_WEAK("finalizer scheduled");
-        }
-    }
+    var i, w;
+
     TRACE_WEAK("to finalize: " + toFinalize.length);
     // start a finalizer thread if any finalizers need to be run
     if(toFinalize.length > 0) {
@@ -45,8 +35,6 @@ function h$finalizeWeaks() {
         }
         h$wakeupThread(t);
     }
-    return toFinalize;
-
 }
 
 // clear references for reachable weak refs with unreachable keys

--- a/src/weak.js
+++ b/src/weak.js
@@ -4,8 +4,7 @@
 // contains all pending finalizers
 var h$finalizers = new h$Set();
 
-// filled at scan time, weak refs with possible work to do
-var h$scannedWeaks = [];
+var h$weakPointerList = [];
 
 #ifdef GHCJS_TRACE_WEAK
 function h$traceWeak() { h$log.apply(h$log, arguments) }


### PR DESCRIPTION
Working on a sodium FRP based code compiled with ghcjs, I noticed that roughly after ~2sec the event propagations seemd to stop. This was reported here https://github.com/ghcjs/ghcjs/issues/296 a year ago, and most recently also discussed in an issue of the sodium repo here: https://github.com/SodiumFRP/sodium/issues/70.

In the meantime I have switched from [sodium](https://github.com/SodiumFRP/sodium) to [reactive-banana](https://github.com/HeinrichApfelmus/reactive-banana), as sodium for haskell was deprecated by @the-real-blackh in favor of reactive-banana. reactive-banana show the very same effect. Stops after ~2 seconds, which is basicly when the GC goes around.

From the more recent ticke a discussion between @luite (ghcjs) and @HeinrichApfelmus (reactive-banana) [spawned here on redit](https://www.reddit.com/r/haskell/comments/3ly4pe/which_frontend_library_to_use_with_ghcjs/cvb5t2a) which encouraged me to read the original paper on this topic: [Stretching the storage manager: weak pointers and stable names in Haskell ](http://research.microsoft.com/en-us/um/people/simonpj/Papers/weak.htm)

In this pull request I tried to implement the semantics as close to the Paper I could. Although this is the first time for me working on the ghcjs rts, so especialy the semantics within the GC are new for me, so I propably produced memory leaks or other stuff. And there is probably also space for optimization, because my first goal was to implement it as close to the paper above as possible.

I also have not done any testing or benchmarking, although my sodium/reactive-banana code now keeps working and does not die after the GC has hit.

In the meantime there also exists an issue in the reactive-banana issue tracker here: https://github.com/HeinrichApfelmus/reactive-banana/issues/109