### PR TITLE
setImmediate global object weirdness

### DIFF
--- a/lib/setImmediate/setImmediate.js
+++ b/lib/setImmediate/setImmediate.js
@@ -182,4 +182,4 @@
 
     attachTo.setImmediate = setImmediate;
     attachTo.clearImmediate = clearImmediate;
-}(this));
+}(h$getGlobal(this)));


### PR DESCRIPTION
I think it should be something like this?

Because otherwise, on node.js (v4.1.1 x64), it doesn't detect platform `setImmediate` and uses `setTimeout`-based shim instead.