### PR TITLE
Fix timezones getting wrong offset minutes.

### DIFF
--- a/pkg/time.js
+++ b/pkg/time.js
@@ -2,7 +2,7 @@ function h$get_current_timezone_seconds(t, pdst_v, pdst_o, pname_v, pname_o) {
     var d      = new Date(t);
     var now    = new Date();
     var jan    = new Date(now.getFullYear(),0,1);
-    var jul    = new Date(now.getFullYear(),0,1);
+    var jul    = new Date(now.getFullYear(),0,7);
     var stdOff = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
     var isDst  = d.getTimezoneOffset() < stdOff;
     var tzo    = d.getTimezoneOffset();
@@ -10,5 +10,5 @@ function h$get_current_timezone_seconds(t, pdst_v, pdst_o, pname_v, pname_o) {
     if(!pname_v.arr) pname_v.arr = [];
     var offstr = tzo < 0 ? ('+' + (tzo/-60)) : ('' + (tzo/-60));
     pname_v.arr[pname_o] = [h$encodeUtf8("UTC" + offstr), 0];
-    return (3600-60*tzo)|0;
+    return (-60*tzo)|0;
 }


### PR DESCRIPTION
This fixes a bug whereas when Data.Time.LocalTime.getCurrentTimeZone is called the TimeZOne instance gets a wrong number of minutes as offset.