### PR TITLE
Construct January and especially July dates properly

### DIFF
--- a/pkg/time.js
+++ b/pkg/time.js
@@ -1,8 +1,8 @@
 function h$get_current_timezone_seconds(t, pdst_v, pdst_o, pname_v, pname_o) {
     var d      = new Date(t);
     var now    = new Date();
-    var jan    = new Date(now.getFullYear(),0,1);
-    var jul    = new Date(now.getFullYear(),0,7);
+    var jan    = new Date(now.getFullYear(),1,1);
+    var jul    = new Date(now.getFullYear(),7,1);
     var stdOff = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
     var isDst  = d.getTimezoneOffset() < stdOff;
     var tzo    = d.getTimezoneOffset();


### PR DESCRIPTION
Month is the second parameter to Date's constructor, not the third.

See http://ircbrowse.net/browse/ghcjs?events_page=4556

I'm not 100% convinced this is entirely correct, as it isn't entirely obvious what the rest of the code is doing, but at least it gives the correct time zone in US/Pacific during DST now.