### PR TITLE
Drop listProps

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -45,17 +45,6 @@ function h$typeOf(o) {
     }
 }
 
-function h$listProps(o) {
-    if (!(o instanceof Object)) {
-        return [];
-    }
-    var l = [], i = 0;
-    for (var prop in o) {
-        l[i++] = prop;
-    }
-    return l;
-}
-
 function h$flattenObj(o) {
     var l = [], i = 0;
     for (var prop in o) {


### PR DESCRIPTION
`listProps` is defined in shims, and again in `"ghcjs-base" Javascript.Object.Internal`.

This PR deletes the one in shims. Was it used anywhere?

Related issues:
https://github.com/ghcjs/ghcjs/issues/556
https://github.com/ghcjs/ghcjs/issues/572
https://github.com/ghcjs/ghcjs-base/pull/70