### PR TITLE
set `__ghcjsArray` when slicing array

### DIFF
--- a/src/mem.js
+++ b/src/mem.js
@@ -497,7 +497,10 @@ function h$callDynamic(f) {
 
 // slice an array of heap objects
 function h$sliceArray(a, start, n) {
-  return a.slice(start, start+n);
+  var r = a.slice(start, start+n);
+  r.__ghcjsArray = true;
+  r.m = 0;
+  return r;
 }
 
 function h$memcpy() {


### PR DESCRIPTION
I was not able to test this properly, but intuitively the old copying operations are wrong since they lose the __ghcjsArray property.

This PR together with https://github.com/ghcjs/ghcjs/pull/619 fixes https://github.com/ghcjs/ghcjs/issues/463 .