### PR TITLE
Fixes a bug in the toHsStringMU8.

### DIFF
--- a/src/string.js
+++ b/src/string.js
@@ -600,7 +600,7 @@ function h$toHsStringMU8(arr, cc) {
 #else
 function h$toHsStringMU8(arr) {
 #endif
-    var accept = false, b, n = 0, cp = 0, r = HS_NIL;
+    var i = arr.length - 1, accept = false, b, n = 0, cp = 0, r = HS_NIL;
     while(i >= 0) {
         b = arr[i];
         if(!(b & 128)) {


### PR DESCRIPTION
The variable `i` wasn't being declared / initialized before the while loop.